### PR TITLE
feat: show ignore reason tooltip on IGNORE results

### DIFF
--- a/islands/ReportTable.tsx
+++ b/islands/ReportTable.tsx
@@ -359,7 +359,14 @@ function Result(
     return <span class="text-green-500 dark:text-green-400">PASS</span>;
   }
   if (result[0] === "IGNORE") {
-    return <span class="text-gray-500 dark:text-gray-400">IGNORE</span>;
+    const reason = result[2]?.ignoreReason || "(no reason specified)";
+    return (
+      <span class="text-gray-500 dark:text-gray-400 relative group">
+        IGNORE
+        <span class="text-xs ml-0.5 cursor-help">?</span>
+        <ErrorTooltip text={reason} />
+      </span>
+    );
   }
   const error = result[1];
   if (error) {

--- a/util/types.ts
+++ b/util/types.ts
@@ -2,6 +2,7 @@
 
 type SingleResultOption = {
   usesNodeTest?: boolean;
+  ignoreReason?: string;
 };
 
 export type SingleResult =


### PR DESCRIPTION
## Summary
- Add `ignoreReason` field to `SingleResultOption` type to match actual API data
- Display a `?` indicator next to IGNORE results that shows the reason on hover
- Falls back to "(no reason specified)" when no reason is available

## Test plan
- [ ] Navigate to a day detail page with IGNORE results
- [ ] Verify `?` appears next to IGNORE text
- [ ] Hover over IGNORE to see the reason tooltip
- [ ] Verify tests without an ignore reason show "(no reason specified)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)